### PR TITLE
add reach properties from NHDPlus data

### DIFF
--- a/watershed_workflow/sources/manager_nhd.py
+++ b/watershed_workflow/sources/manager_nhd.py
@@ -114,8 +114,7 @@ class _FileManagerNHD:
         profile['always_xy'] = True
         return profile, hus
         
-    def get_hydro(self, huc, bounds=None, bounds_crs=None, in_network=True,
-                  include_catchments=False, include_catchment_areas=False,
+    def get_hydro(self, huc, bounds=None, bounds_crs=None, in_network=True, properties=None,
                   force_download=False):
         """Get all reaches within a given HUC and/or coordinate bounds.
 
@@ -130,14 +129,10 @@ class _FileManagerNHD:
           CRS of the above bounds.
         in_network : bool, optional
           If True (default), remove reaches that are not "in" the NHD network
-        include_catchments : bool, optional
-          If True (default is False) and data source is NHDPlus, attach the 
-          reach catchment as a property to every reach.
-        include_catchment_areas : bool, optional
-          If True (default is False) and data source is NHDPlus, attach the 
-          reach catchment area as a property, in the native coordinate system.
+        properties : a list of properties to be added to reaches 'catchment' for catchment geometry, and property alias names for NHDPlusFlowlineVAA and NHDPlusEROMMA table 
+          (Table 16 and 17 NHDPlus user guide)
         force_download : bool
-          Download or re-download the file if true.
+        Download or re-download the file if true.
 
         Returns
         -------
@@ -147,7 +142,8 @@ class _FileManagerNHD:
           List of fiona shape objects representing the stream reaches.
 
         Note this finds and downloads files as needed.
-        """        
+        """  
+        
         if 'WBD' in self.name:
             raise RuntimeError('{}: does not provide hydrographic data.'.format(self.name))
         
@@ -184,27 +180,54 @@ class _FileManagerNHD:
             reaches = [r for r in reaches if 'InNetwork' in r['properties'] and r['properties']['InNetwork'] == 1]
 
         # associate catchment areas with the reaches if NHDPlus
-        if 'Plus' in self.name and include_catchments or include_catchment_areas:
+        if 'Plus' in self.name and properties != None:
             reach_dict = dict((r['properties']['NHDPlusID'],r) for r in reaches)
-            layer = 'NHDPlusCatchment'
-            logging.info("  {}: opening '{}' layer '{}' for catchment areas in '{}'".format(self.name, filename, layer, bounds))
 
-            if include_catchments:
-                for r in reaches:
-                    r['properties']['catchment'] = None
-            if include_catchment_areas:
-                for r in reaches:
-                    r['properties']['area'] = 0
+            # these dictionaries are needed to access properties from NHDPLus tables {'property alias name': 'property key/code'} 
+            # Want to support more properties?? Add their alias names and codes in respective dictionaries (Table 16 and 17 NHDPlus user guide)
+            layer_vaa = dict({'StreamOrder':'StreamOrde' ,'StreamLevel':'StreamLeve' ,'HydrologicSequence': 'HydroSeq','DivergenceCode':'Divergence' , 'CatchmentAreaSqKm':'AreaSqKm' , 'TotalDrainageAreaSqKm':'TotDASqKm' })
+            layer_erroma = dict({'MeanAnnualFlow':'QAMA' ,'MeanAnnualVelocity':'VAMA' ,'MeanAnnualFlowGaugeAdj': 'QEMA'})
+            
+            # validation of properties
+            valid_props=list(layer_vaa.keys())+list(layer_erroma.keys())+['catchments']
+            for prop in properties:
+                assert(prop in valid_props)
 
-            with fiona.open(filename, mode='r', layer=layer) as fid:
-                for catchment in fid.values():
-                    reach = reach_dict.get(catchment['properties']['NHDPlusID'])
-                    if reach is not None:
-                        if include_catchments:
-                            reach['properties']['catchment'] = catch
-                        if include_catchment_areas:
-                            reach['properties']['area'] = watershed_workflow.utils.shply(catchment).area
+            # flags for which layers will be needed
+            layer_flags=dict({'catchments': 'catchments' in properties ,'vaa': not set(properties).isdisjoint(list(layer_vaa.keys())),'erroma':not set(properties).isdisjoint(list(layer_erroma.keys()))})        
+            if layer_flags['catchments']:
+                layer = 'NHDPlusCatchment'
+                logging.info("  {}: opening '{}' layer '{}' for catchments in '{}'".format(self.name, filename, layer, bounds))
+                with fiona.open(filename, mode='r', layer=layer) as fid:
+                    for catchment in fid.values():
+                        reach = reach_dict.get(catchment['properties']['NHDPlusID'])                      
+                        if reach is not None:
+                            reach['properties']['catchment'] = catchment
 
+            if layer_flags['vaa']:
+                layer = 'NHDPlusFlowlineVAA'
+                logging.info("  {}: opening '{}' layer '{}' for river network properties in '{}'".format(self.name, filename, layer, bounds))
+                with fiona.open(filename, mode='r', layer=layer) as fid:
+                    for flowline in fid.values():
+                        reach = reach_dict.get(flowline['properties']['NHDPlusID'])
+                        if reach is not None:
+                            for prop in properties:
+                                if prop in list(layer_vaa.keys()):
+                                    prop_code=layer_vaa[prop]
+                                    reach['properties'][prop] = flowline['properties'][prop_code]
+
+            if layer_flags['erroma']:
+                layer = 'NHDPlusEROMMA'
+                logging.info("  {}: opening '{}' layer '{}' for river network properties in '{}'".format(self.name, filename, layer, bounds))
+                with fiona.open(filename, mode='r', layer=layer) as fid:
+                    for flowline in fid.values():
+                        reach = reach_dict.get(flowline['properties']['NHDPlusID'])
+                        if reach is not None:
+                            for prop in properties:
+                                if prop in list(layer_erroma.keys()):
+                                    prop_code=layer_erroma[prop]
+                                    reach['properties'][prop] = flowline['properties'][prop_code]
+          
         return profile, reaches
             
     def _url(self, hucstr):


### PR DESCRIPTION
provide a way to include additional useful data from NHDPlus as reach properties.

This includes:
- catchments
- NHDPlusFlowVAA table
- NHDPlusEromma table

Currently only select properties are supported from these tables. This can be easily expanded by adding more alias names in the dictionary of alias names and codes provided in manager_nhd.py. 